### PR TITLE
ci(notification): add discord webhook notification workflow

### DIFF
--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -1,0 +1,26 @@
+name: Pull Request Notifications
+
+on:
+  pull_request:
+    types: [opened, reopened, closed]
+
+jobs:
+  pull_request_created:
+    if: github.event_name == 'pull_request' && github.event.action == 'opened' || github.event.action == 'reopened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v5.3.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          content: "Pull request opened: ${{ github.event.pull_request.title }} | Link: [View Pull Request](${{ github.event.pull_request.html_url }})"
+
+  pull_request_merged:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v5.3.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          content: "Pull request merged: ${{ github.event.pull_request.title }}"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

I've added back the Discord web hook notification. Note that you will need to set the web hook url into the repository's secrets. 

You can find that here:

1. Open "Edit Channel" on the `#pr` channel

<img width="337" height="79" alt="Screenshot 2025-09-20 at 4 22 06 PM" src="https://github.com/user-attachments/assets/aa8b50d8-d482-4bc9-8eae-673d86c0da51" />

2. Go to "Integrations" tab

<img width="278" height="179" alt="Screenshot 2025-09-20 at 4 22 17 PM" src="https://github.com/user-attachments/assets/3c32c905-b5f4-4aea-b92a-8f7b47c38a10" />

3. Open the web hook and click "Copy Webhook URL"

<img width="724" height="428" alt="Screenshot 2025-09-20 at 4 22 40 PM" src="https://github.com/user-attachments/assets/452ef417-9001-48ab-acb1-473b5922e95f" />

4. On GitHub: Open Settings -> Secrets and variables -> Actions -> New repository secret

Set the name as `DISCORD_WEBHOOK_URL` and the value as the copied secret. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [ ] I've requested a review from another user
